### PR TITLE
docs: add Codeberg repo mirror link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A simple, fast, all-in-one config loader for Zig. Supports reading dotenv, toml,
 yaml and os env. Fully-functional and tested on Zig 0.15.2.
 
+🏔️ Codeberg Mirror: https://codeberg.org/omkar-foss/zebra
+
 ## Design
 
 - Inspired by the wonderful [viper (golang)](https://github.com/spf13/viper). Stripes instead of


### PR DESCRIPTION
Closes #2.

This PR adds Zebra's Codeberg repo mirror link to readme.