### PR TITLE
Add cli interface to zebra with supporting tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ zig-out/
 
 # vscode, vscodium
 .vscode/
+
+# zebra-related
+zebra

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ all: build
 build:
 	@echo "Build the project..."
 	zig build
+	mv zig-out/bin/zebra .
 
-test:
+test: clean build
 	@echo "Running tests..."
 	zig build test --summary all
 
@@ -27,4 +28,4 @@ format:
 
 clean:
 	@echo "Cleaning up..."
-	rm -rf .zig-cache zig-out
+	rm -rf .zig-cache zig-out zebra

--- a/build.zig
+++ b/build.zig
@@ -145,7 +145,7 @@ pub fn build(b: *std.Build) void {
     // test_step.dependOn(&run_mod_tests.step);
     // test_step.dependOn(&run_exe_tests.step);
 
-    // integration tests externally defined in tests folder.
+    // integration tests defined in tests folder.
     const integration_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("tests/integration.zig"),
@@ -156,6 +156,18 @@ pub fn build(b: *std.Build) void {
     integration_tests.root_module.addImport("zebra", mod);
     const run_integration_tests = b.addRunArtifact(integration_tests);
     test_step.dependOn(&run_integration_tests.step);
+
+    // cli integration tests defined in tests folder.
+    const cli_integration_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/cli_integration.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    cli_integration_tests.root_module.addImport("zebra", mod);
+    const run_cli_integration_tests = b.addRunArtifact(cli_integration_tests);
+    test_step.dependOn(&run_cli_integration_tests.step);
 
     // Just like flags, top level steps are also listed in the `--help` menu.
     //

--- a/src/inputs/core.zig
+++ b/src/inputs/core.zig
@@ -6,7 +6,7 @@ const yaml = @import("yaml.zig");
 const cleanup = @import("../utils/cleanup.zig");
 const security = @import("../utils/security.zig");
 
-pub const LoadOpts = struct { unmask: bool = false };
+pub const LoadOpts = struct { unmask: bool = false, cli_mode: bool = false };
 
 /// Identifies file types and merges them into single configuration string hash map.
 pub fn loadAsMap(allocator: std.mem.Allocator, paths: []const []const u8, opts: LoadOpts) !std.StringHashMap([]u8) {
@@ -50,27 +50,30 @@ pub fn loadAsMap(allocator: std.mem.Allocator, paths: []const []const u8, opts: 
         cleanup.deinitMap(allocator, &file_map);
     }
 
-    // overwrite with values obtained from os env, as it always takes priority over files
-    var osenv_map = try osenv.loadAsMap(allocator);
-    var osenv_iter = osenv_map.iterator();
-    while (osenv_iter.next()) |entry| {
-        const new_key = try allocator.dupe(u8, entry.key_ptr.*);
-        var new_val: []u8 = undefined;
-        const keep_masked = opts.unmask == false;
-        const isSensitiveKey = try security.isSensitiveKey(new_key);
+    // we don't load os env variables in cli mode wherein args are specified via input files only.
+    if (!opts.cli_mode) {
+        // overwrite with values obtained from os env, as it always takes priority over files
+        var osenv_map = try osenv.loadAsMap(allocator);
+        var osenv_iter = osenv_map.iterator();
+        while (osenv_iter.next()) |entry| {
+            const new_key = try allocator.dupe(u8, entry.key_ptr.*);
+            var new_val: []u8 = undefined;
+            const keep_masked = opts.unmask == false;
+            const isSensitiveKey = try security.isSensitiveKey(new_key);
 
-        if (keep_masked and isSensitiveKey) {
-            new_val = try allocator.dupe(u8, "XXXX");
-        } else {
-            new_val = try allocator.dupe(u8, entry.value_ptr.*);
-        }
+            if (keep_masked and isSensitiveKey) {
+                new_val = try allocator.dupe(u8, "XXXX");
+            } else {
+                new_val = try allocator.dupe(u8, entry.value_ptr.*);
+            }
 
-        if (try master_map.fetchPut(new_key, new_val)) |old| {
-            allocator.free(new_key);
-            allocator.free(old.value);
+            if (try master_map.fetchPut(new_key, new_val)) |old| {
+                allocator.free(new_key);
+                allocator.free(old.value);
+            }
         }
+        cleanup.deinitMap(allocator, &osenv_map);
     }
-    cleanup.deinitMap(allocator, &osenv_map);
 
     return master_map;
 }

--- a/src/inputs/dotenv.zig
+++ b/src/inputs/dotenv.zig
@@ -8,7 +8,7 @@ pub fn loadAsMap(allocator: std.mem.Allocator, path: []const u8) !std.StringHash
 
     var map = std.StringHashMap([]u8).init(allocator);
 
-    var file_buf: [1024]u8 = undefined;
+    var file_buf: [4096]u8 = undefined;
     var reader_wrapper = file.reader(&file_buf);
     const reader = &reader_wrapper.interface;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,106 @@
 const std = @import("std");
 const zebra = @import("root.zig");
 
+const CliArgs = struct {
+    inputs: std.ArrayList([]const u8),
+    output: ?[]const u8,
+    keys: std.ArrayList([]const u8),
+};
+
+fn logToStdOut(contents: []const u8) !void {
+    var buf: [4096]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&buf);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{s}\n", .{contents});
+    try stdout.flush();
+}
+
+fn printHelp() !void {
+    try logToStdOut(
+        \\Welcome to Zebra! Just a striped config costume for Zig 🦓
+        \\
+        \\Usage:
+        \\  zebra --input <file1> [--input <file2> ...] [--output <file> | STDOUT] [--key KEY_1 --key KEY_2 ...]
+        \\
+        \\Options:
+        \\  -i, --input <file>     input file(s), at least one required
+        \\  -o, --output <file>    json output file, defaults to STDOUT
+        \\  -k, --key              key(s) to include, defaults to all keys
+        \\  -h, --help             Show this help message
+        \\
+        \\Example:
+        \\  zebra --input service1.toml --input .env.service2 --output services.json
+        \\
+    );
+}
+
 pub fn main() !void {
-    std.debug.print("Welcome to Zebra! Just a striped config costume for Zig 🦓\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+
+    var args = try std.process.argsWithAllocator(allocator);
+    defer args.deinit();
+
+    // Skip executable name
+    _ = args.skip();
+
+    var cli = CliArgs{ .inputs = std.ArrayList([]const u8){}, .output = null, .keys = std.ArrayList([]const u8){} };
+    defer {
+        cli.inputs.deinit(allocator);
+        cli.keys.deinit(allocator);
+    }
+
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            try printHelp();
+            return;
+        } else if (std.mem.eql(u8, arg, "--input") or std.mem.eql(u8, arg, "-i")) {
+            const value = args.next() orelse {
+                std.log.err("missing value for --input\n", .{});
+                try printHelp();
+                std.process.exit(1);
+            };
+            try cli.inputs.append(allocator, value);
+        } else if (std.mem.eql(u8, arg, "--output") or std.mem.eql(u8, arg, "-o")) {
+            const value = args.next() orelse {
+                std.log.err("missing value for --output\n", .{});
+                try printHelp();
+                std.process.exit(1);
+            };
+            cli.output = value;
+        } else if (std.mem.eql(u8, arg, "--key") or std.mem.eql(u8, arg, "-k")) {
+            const value = args.next() orelse {
+                std.log.err("missing value for --key\n", .{});
+                try printHelp();
+                std.process.exit(1);
+            };
+            try cli.keys.append(allocator, value);
+        } else {
+            std.log.err("unknown argument: {s}\n", .{arg});
+            try printHelp();
+            std.process.exit(1);
+        }
+    }
+
+    if (cli.inputs.items.len == 0) {
+        std.log.err("at least one input file is required\n", .{});
+        try printHelp();
+        std.process.exit(1);
+    }
+
+    var cfg = try zebra.core.loadAsMap(allocator, cli.inputs.items, .{ .unmask = false, .cli_mode = true });
+    defer zebra.cleanup.deinitMap(allocator, &cfg);
+
+    const json = try zebra.outputs.json.toStringMap(allocator, cfg, cli.keys.items);
+    defer allocator.free(json);
+
+    if (cli.output == null) {
+        std.log.warn("output file isn't specified, defaulting to STDOUT.\n", .{});
+        try logToStdOut(json);
+    } else {
+        try zebra.outputs.json.writeToFile(json, cli.output.?);
+        std.log.info("output json written to file path: {s}", .{cli.output.?});
+    }
 }

--- a/src/outputs/json.zig
+++ b/src/outputs/json.zig
@@ -13,11 +13,38 @@ pub fn toStringMap(allocator: std.mem.Allocator, map: anytype, keys: []const []c
     var json_ready_map = JsonMap{};
     defer json_ready_map.deinit(allocator);
 
-    for (keys) |key| {
-        if (map.get(key)) |value| {
-            try json_ready_map.map.put(allocator, key, value);
+    if (keys.len > 0) {
+        for (keys) |key| {
+            if (map.get(key)) |value| {
+                try json_ready_map.map.put(allocator, key, value);
+            }
+        }
+    } else {
+        var iter = map.iterator();
+        while (iter.next()) |entry| {
+            try json_ready_map.map.put(
+                allocator,
+                entry.key_ptr.*,
+                entry.value_ptr.*,
+            );
         }
     }
 
     return toString(allocator, JsonMap, json_ready_map);
+}
+
+pub fn writeToFile(json_string: []const u8, file_path: []const u8) !void {
+    const file = try std.fs.cwd().createFile(file_path, .{
+        .read = false,
+        .truncate = true,
+        .mode = 0o400,
+    });
+    defer file.close();
+
+    var write_buffer: [4096]u8 = undefined;
+    var buffered_file_writer = file.writer(&write_buffer);
+    const writer = &buffered_file_writer.interface;
+
+    try writer.writeAll(json_string);
+    try writer.flush();
 }

--- a/tests/cli_integration.zig
+++ b/tests/cli_integration.zig
@@ -1,0 +1,177 @@
+const std = @import("std");
+
+test "cli: --help flag prints the help text" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{
+            "./zebra",
+            "--help",
+        },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stdout = try child.stdout.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stdout);
+    const term = try child.wait();
+
+    try std.testing.expectStringStartsWith(
+        stdout,
+        "Welcome to Zebra!",
+    );
+    try std.testing.expect(term.Exited == 0);
+}
+
+test "cli: -h flag also prints the help text" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{
+            "./zebra",
+            "-h",
+        },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stdout = try child.stdout.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stdout);
+    const term = try child.wait();
+
+    try std.testing.expectStringStartsWith(
+        stdout,
+        "Welcome to Zebra!",
+    );
+    try std.testing.expect(term.Exited == 0);
+}
+
+test "cli: --input flag reads the specified file" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{ "./zebra", "--input", "env_test.toml" },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stdout = try child.stdout.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stdout);
+    const term = try child.wait();
+
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"127.0.0.1\": \"localhost\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"nested_arrays\": \"[ [ 1, 2 ], [3, 4, 5] ]\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"products.0.name\": \"Hammer\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AZURE_CLIENT_SECRET\": \"XXXX\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AWS_SECRET_ACCESS_KEY\": \"XXXX\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"quoted . dot\": \"allowed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"float_inf\": \"inf\"") != null);
+    try std.testing.expect(term.Exited == 0);
+}
+
+test "cli: -i flag reads the specified file" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{ "./zebra", "-i", "env_test.toml" },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stdout = try child.stdout.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stdout);
+    const term = try child.wait();
+
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"127.0.0.1\": \"localhost\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"nested_arrays\": \"[ [ 1, 2 ], [3, 4, 5] ]\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"products.0.name\": \"Hammer\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AZURE_CLIENT_SECRET\": \"XXXX\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AWS_SECRET_ACCESS_KEY\": \"XXXX\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"quoted . dot\": \"allowed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"float_inf\": \"inf\"") != null);
+    try std.testing.expect(term.Exited == 0);
+}
+
+test "cli: -k flag only build output json for specific keys from the specified file - case 1 (single key)" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{ "./zebra", "-i", "env_test.toml", "-k", "float_inf" },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stdout = try child.stdout.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stdout);
+    const term = try child.wait();
+
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"127.0.0.1\": \"localhost\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"nested_arrays\": \"[ [ 1, 2 ], [3, 4, 5] ]\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"products.0.name\": \"Hammer\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AZURE_CLIENT_SECRET\": \"XXXX\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AWS_SECRET_ACCESS_KEY\": \"XXXX\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"quoted . dot\": \"allowed\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"float_inf\": \"inf\"") != null);
+    try std.testing.expect(term.Exited == 0);
+}
+
+test "cli: -k flag only build output json for specific keys from the specified file - case 2 (two keys)" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{ "./zebra", "-i", "env_test.toml", "-k", "float_inf", "-k", "products.0.name" },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stdout = try child.stdout.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stdout);
+    const term = try child.wait();
+
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"127.0.0.1\": \"localhost\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"nested_arrays\": \"[ [ 1, 2 ], [3, 4, 5] ]\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AZURE_CLIENT_SECRET\": \"XXXX\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"AWS_SECRET_ACCESS_KEY\": \"XXXX\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"quoted . dot\": \"allowed\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"products.0.name\": \"Hammer\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "\"float_inf\": \"inf\"") != null);
+    try std.testing.expect(term.Exited == 0);
+}
+
+test "cli: --input flag without --output flag shows an warning to use STDOUT as default output" {
+    const allocator = std.testing.allocator;
+    var child = std.process.Child.init(
+        &.{ "./zebra", "-i", "env_test.toml" },
+        allocator,
+    );
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+    const stderr = try child.stderr.?.readToEndAlloc(
+        allocator,
+        4096,
+    );
+    defer allocator.free(stderr);
+    const term = try child.wait();
+
+    try std.testing.expectStringStartsWith(stderr, "warning: output file isn't specified, defaulting to STDOUT.");
+    try std.testing.expect(term.Exited == 0);
+}


### PR DESCRIPTION
Closes #6.

This PR adds a cli interface to zebra's functionality with supporting tests. It also fixes buf size in `src/inputs/dotenv.zig` to 4096 for (potentially) reduced syscalls.

Usage as follows:
```bash
$ zebra --input service1.toml --input service2.toml
```

Output will be a json string containing keys merged from both service 1 & 2 tomls, same functionality as if zebra is loaded as zig package.